### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ function set(object, path, value, initPaths, joiner) {
 
   while (i < len) {
     var key = keys[i++];
-    if (initPaths && !hasOwnProperty.call(object, key)) object[key] = {};
+    if (initPaths && !hasOwnProperty.call(object, key) || isPrototypePolluted(key)) object[key] = {};
     object = object[key];
   }
 
@@ -383,6 +383,15 @@ function merge(target, source) {
     }
   }
   return target;
+}
+
+/**
+ * 
+ * @param key
+ * @returns {boolean}
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'constructor', 'prototype'].includes(key)
 }
 
 module.exports.get = get;

--- a/index.js
+++ b/index.js
@@ -391,7 +391,7 @@ function merge(target, source) {
  * @returns {boolean}
  */
 function isPrototypePolluted(key) {
-  return ['__proto__', 'constructor', 'prototype'].includes(key)
+  return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 module.exports.get = get;

--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ function get(object, path, joiner) {
  * @param joiner
  */
 function set(object, path, value, initPaths, joiner) {
-  if (!isObject(object)) return false;
+  if (!isObject(object) || object === constructor.prototype) return false;
   var keys = path.split(joiner || '.');
 
   var i = 0;


### PR DESCRIPTION
### :bar_chart: Metadata *

`deeps` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-deeps

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { set } = require('deeps')
console.log(`Before: ${{}.polluted}`)
set(constructor.prototype, 'polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i deeps # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/103887526-2f985500-5109-11eb-8f2f-104c2881a572.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
